### PR TITLE
Code quality fix - "public static" fields should be constant

### DIFF
--- a/jdroid-android-google-maps/src/test/java/com/jdroid/android/TestDebugContext.java
+++ b/jdroid-android-google-maps/src/test/java/com/jdroid/android/TestDebugContext.java
@@ -4,7 +4,7 @@ import com.jdroid.android.debug.DebugContext;
 
 public class TestDebugContext extends DebugContext {
 
-	public static Boolean FAKE_HTTP_ENABLED = true;
+	public static final Boolean FAKE_HTTP_ENABLED = true;
 
 	@Override
 	public Boolean isHttpMockEnabled() {

--- a/jdroid-android-sample/src/test/java/com/jdroid/android/sample/TestDebugContext.java
+++ b/jdroid-android-sample/src/test/java/com/jdroid/android/sample/TestDebugContext.java
@@ -4,7 +4,7 @@ import com.jdroid.android.debug.DebugContext;
 
 public class TestDebugContext extends DebugContext {
 
-	public static Boolean FAKE_HTTP_ENABLED = true;
+	public static final Boolean FAKE_HTTP_ENABLED = true;
 
 	@Override
 	public Boolean isHttpMockEnabled() {

--- a/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationBuilder.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationBuilder.java
@@ -28,7 +28,7 @@ public class NotificationBuilder {
 	
 	public static final String NOTIFICATION_NAME = "notificationName";
 
-	public static String NOTIFICATION_URI = "notification://";
+	public static final String NOTIFICATION_URI = "notification://";
 	
 	private String notificationName;
 	private NotificationCompat.Builder builder;

--- a/jdroid-android/src/main/java/com/jdroid/android/social/twitter/TwitterConnector.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/social/twitter/TwitterConnector.java
@@ -9,8 +9,8 @@ import com.jdroid.android.social.SocialAction;
 
 public class TwitterConnector {
 	
-	public static Integer CHARACTERS_LIMIT = 140;
-	public static Integer URL_CHARACTERS_COUNT = 22;
+	public static final Integer CHARACTERS_LIMIT = 140;
+	public static final Integer URL_CHARACTERS_COUNT = 22;
 	
 	public static void openProfile(String account) {
 		try {

--- a/jdroid-android/src/test/java/com/jdroid/android/TestDebugContext.java
+++ b/jdroid-android/src/test/java/com/jdroid/android/TestDebugContext.java
@@ -4,7 +4,7 @@ import com.jdroid.android.debug.DebugContext;
 
 public class TestDebugContext extends DebugContext {
 
-	public static Boolean FAKE_HTTP_ENABLED = true;
+	public static final Boolean FAKE_HTTP_ENABLED = true;
 
 	@Override
 	public Boolean isHttpMockEnabled() {

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/twitter/TwitterConnector.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/twitter/TwitterConnector.java
@@ -19,8 +19,8 @@ public class TwitterConnector {
 	
 	private static final Logger LOGGER = LoggerUtils.getLogger(TwitterConnector.class);
 	
-	public static Integer CHARACTERS_LIMIT = 140;
-	public static Integer URL_CHARACTERS_COUNT = 22;
+	public static final Integer CHARACTERS_LIMIT = 140;
+	public static final Integer URL_CHARACTERS_COUNT = 22;
 	
 	private TwitterFactory twitterFactory;
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Soso Tughushi