### PR TITLE
Code quality fix - Null should not be returned from a "Boolean" method.

### DIFF
--- a/jdroid-android-google-maps/src/test/java/com/jdroid/android/TestAppContext.java
+++ b/jdroid-android-google-maps/src/test/java/com/jdroid/android/TestAppContext.java
@@ -26,7 +26,7 @@ public class TestAppContext extends AppContext {
 
 	@Override
 	public Boolean isGoogleAnalyticsDebugEnabled() {
-		return null;
+		return false;
 	}
 
 	@Override

--- a/jdroid-android-sample/src/test/java/com/jdroid/android/sample/TestAppContext.java
+++ b/jdroid-android-sample/src/test/java/com/jdroid/android/sample/TestAppContext.java
@@ -26,7 +26,7 @@ public class TestAppContext extends AppContext {
 
 	@Override
 	public Boolean isGoogleAnalyticsDebugEnabled() {
-		return null;
+		return false;
 	}
 
 	@Override

--- a/jdroid-android/src/main/java/com/jdroid/android/fragment/AbstractPreferenceFragment.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/fragment/AbstractPreferenceFragment.java
@@ -241,7 +241,7 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment impl
 
 	@Override
 	public Boolean isSecondaryFragment() {
-		return null;
+		return false;
 	}
 
 	@Override

--- a/jdroid-android/src/main/java/com/jdroid/android/sqlite/DataType.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/sqlite/DataType.java
@@ -158,7 +158,7 @@ public enum DataType {
 		public Boolean readValue(Cursor cursor, String columnName) {
 			int columnIndex = cursor.getColumnIndex(columnName);
 			if (cursor.isNull(columnIndex)) {
-				return null;
+				return false;
 			}
 			return (cursor.getInt(columnIndex) == 0 ? Boolean.FALSE : Boolean.TRUE);
 		}

--- a/jdroid-android/src/test/java/com/jdroid/android/TestAppContext.java
+++ b/jdroid-android/src/test/java/com/jdroid/android/TestAppContext.java
@@ -26,7 +26,7 @@ public class TestAppContext extends AppContext {
 
 	@Override
 	public Boolean isGoogleAnalyticsDebugEnabled() {
-		return null;
+		return false;
 	}
 
 	@Override

--- a/jdroid-java/src/main/java/com/jdroid/java/analytics/BaseAnalyticsSender.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/analytics/BaseAnalyticsSender.java
@@ -28,7 +28,7 @@ public class BaseAnalyticsSender<T extends BaseAnalyticsTracker> implements Base
 
 	@Override
 	public Boolean isEnabled() {
-		return null;
+		return false;
 	}
 
 	protected List<T> getTrackers() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2447 - Null should not be returned from a "Boolean" method.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2447

Please let me know if you have any questions.

Soso Tughushi