### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order (part 1)

### DIFF
--- a/jdroid-android-about/src/main/java/com/jdroid/android/about/AboutAppModule.java
+++ b/jdroid-android-about/src/main/java/com/jdroid/android/about/AboutAppModule.java
@@ -18,15 +18,15 @@ public class AboutAppModule extends AbstractAppModule {
 
 	public static final String MODULE_NAME = AboutAppModule.class.getName();
 
-	public static AboutAppModule get() {
-		return (AboutAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
-	}
-
 	private AboutContext aboutContext;
 	private AboutDebugContext aboutDebugContext;
 
 	public AboutAppModule() {
 		aboutContext = createAboutContext();
+	}
+
+	public static AboutAppModule get() {
+		return (AboutAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
 	}
 
 	protected AboutContext createAboutContext() {

--- a/jdroid-android-crashlytics/src/main/java/com/jdroid/android/crashlytics/CrashlyticsAppModule.java
+++ b/jdroid-android-crashlytics/src/main/java/com/jdroid/android/crashlytics/CrashlyticsAppModule.java
@@ -16,11 +16,11 @@ public class CrashlyticsAppModule extends AbstractAppModule {
 
 	public static final String MODULE_NAME = CrashlyticsAppModule.class.getName();
 
+	private CrashlyticsAppContext crashlyticsAppContext;
+
 	public static CrashlyticsAppModule get() {
 		return (CrashlyticsAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
 	}
-
-	private CrashlyticsAppContext crashlyticsAppContext;
 
 	public CrashlyticsAppModule() {
 		crashlyticsAppContext = createCrashlyticsAppContext();

--- a/jdroid-android-google-admob/src/main/java/com/jdroid/android/google/admob/AdMobAppModule.java
+++ b/jdroid-android-google-admob/src/main/java/com/jdroid/android/google/admob/AdMobAppModule.java
@@ -22,15 +22,15 @@ public class AdMobAppModule extends AbstractAppModule {
 
 	public static final String MODULE_NAME = AdMobAppModule.class.getName();
 
-	public static AdMobAppModule get() {
-		return (AdMobAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
-	}
-
 	private AdMobAppContext adMobAppContext;
 	private AdMobDebugContext adMobDebugContext;
 
 	public AdMobAppModule() {
 		adMobAppContext = createAdMobAppContext();
+	}
+
+	public static AdMobAppModule get() {
+		return (AdMobAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
 	}
 
 	protected AdMobAppContext createAdMobAppContext() {

--- a/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/AbstractGcmAppModule.java
+++ b/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/AbstractGcmAppModule.java
@@ -14,10 +14,6 @@ public abstract class AbstractGcmAppModule extends AbstractAppModule {
 
 	public static final String MODULE_NAME = AbstractGcmAppModule.class.getName();
 
-	public static AbstractGcmAppModule get() {
-		return (AbstractGcmAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
-	}
-
 	private GcmDebugContext gcmDebugContext;
 	private GcmMessageResolver gcmMessageResolver;
 	private GcmListenerResolver gcmListenerResolver;
@@ -26,6 +22,10 @@ public abstract class AbstractGcmAppModule extends AbstractAppModule {
 	public AbstractGcmAppModule() {
 		gcmMessageResolver = createGcmMessageResolver();
 		gcmListenerResolver = createGcmListenerResolver();
+	}
+
+	public static AbstractGcmAppModule get() {
+		return (AbstractGcmAppModule)AbstractApplication.get().getAppModule(MODULE_NAME);
 	}
 
 	protected GcmDebugContext createGcmDebugContext() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Soso Tughushi