### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/AbstractGcmMessageResolver.java
+++ b/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/AbstractGcmMessageResolver.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public abstract class AbstractGcmMessageResolver implements GcmMessageResolver {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(AbstractGcmMessageResolver.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(AbstractGcmMessageResolver.class);
 	
 	private static final String MESSAGE_KEY_EXTRA = "messageKey";
 	private static final String USER_ID_KEY = "userIdKey";

--- a/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/GcmRegistrationCommand.java
+++ b/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/GcmRegistrationCommand.java
@@ -23,9 +23,9 @@ import java.util.List;
 
 public class GcmRegistrationCommand extends ServiceCommand {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(GcmRegistrationCommand.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(GcmRegistrationCommand.class);
 
-	private final static String UPDATE_LAST_ACTIVE_TIMESTAMP_EXTRA = "updateLastActiveTimestamp";
+	private static final String UPDATE_LAST_ACTIVE_TIMESTAMP_EXTRA = "updateLastActiveTimestamp";
 
 	public void start(Boolean updateLastActiveTimestamp) {
 		Intent intent = new Intent();

--- a/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/LocaleChangedReceiver.java
+++ b/jdroid-android-google-gcm/src/main/java/com/jdroid/android/google/gcm/LocaleChangedReceiver.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 
 public class LocaleChangedReceiver extends BroadcastReceiver {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(LocaleChangedReceiver.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(LocaleChangedReceiver.class);
 
 	@Override
 	public void onReceive(Context context, Intent intent) {

--- a/jdroid-android-google-inappbilling/src/main/java/com/android/vending/billing/IInAppBillingService.java
+++ b/jdroid-android-google-inappbilling/src/main/java/com/android/vending/billing/IInAppBillingService.java
@@ -13,7 +13,7 @@ package com.android.vending.billing;
  * is consumed. 4. An API to consume a purchase of an inapp item. All purchases of one-time in-app items are consumable
  * and thereafter can be purchased again. 5. An API to get current purchases of the user immediately. This will not
  * contain any consumed purchases.
- * 
+ *
  * All calls will give a response code with the following possible values RESULT_OK = 0 - success RESULT_USER_CANCELED =
  * 1 - user pressed back or canceled a dialog RESULT_BILLING_UNAVAILABLE = 3 - this billing API version is not supported
  * for the type requested RESULT_ITEM_UNAVAILABLE = 4 - requested SKU is not available for purchase
@@ -22,18 +22,18 @@ package com.android.vending.billing;
  * Failure to consume since item is not owned
  */
 public interface IInAppBillingService extends android.os.IInterface {
-	
+
 	/** Local-side IPC implementation stub class. */
 	public static abstract class Stub extends android.os.Binder implements
 			com.android.vending.billing.IInAppBillingService {
-		
+
 		private static final java.lang.String DESCRIPTOR = "com.android.vending.billing.IInAppBillingService";
-		
+
 		/** Construct the stub at attach it to the interface. */
 		public Stub() {
 			this.attachInterface(this, DESCRIPTOR);
 		}
-		
+
 		public static com.android.vending.billing.IInAppBillingService asInterface(android.os.IBinder obj) {
 			if ((obj == null)) {
 				return null;
@@ -44,12 +44,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 			}
 			return new com.android.vending.billing.IInAppBillingService.Stub.Proxy(obj);
 		}
-		
+
 		@Override
 		public android.os.IBinder asBinder() {
 			return this;
 		}
-		
+
 		@Override
 		public boolean onTransact(int code, android.os.Parcel data, android.os.Parcel reply, int flags)
 				throws android.os.RemoteException {
@@ -153,29 +153,29 @@ public interface IInAppBillingService extends android.os.IInterface {
 			}
 			return super.onTransact(code, data, reply, flags);
 		}
-		
+
 		private static class Proxy implements com.android.vending.billing.IInAppBillingService {
-			
+
 			private android.os.IBinder mRemote;
-			
+
 			Proxy(android.os.IBinder remote) {
 				mRemote = remote;
 			}
-			
+
 			@Override
 			public android.os.IBinder asBinder() {
 				return mRemote;
 			}
-			
+
 			@SuppressWarnings("unused")
 			public java.lang.String getInterfaceDescriptor() {
 				return DESCRIPTOR;
 			}
-			
+
 			/**
 			 * Checks support for the requested billing API version, package and in-app type. Minimum API version
 			 * supported by this interface is 3.
-			 * 
+			 *
 			 * @param apiVersion the billing version which the app is using
 			 * @param packageName the package name of the calling app
 			 * @param type type of the in-app item being purchased "inapp" for one-time purchases and "subs" for
@@ -202,12 +202,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 				}
 				return _result;
 			}
-			
+
 			/**
 			 * Provides details of a list of SKUs Given a list of SKUs of a valid type in the skusBundle, this returns a
 			 * bundle with a list JSON strings containing the productId, price, title and description. This API can be
 			 * called with a maximum of 20 SKUs.
-			 * 
+			 *
 			 * @param apiVersion billing API version that the Third-party is using
 			 * @param packageName the package name of the calling app
 			 * @param skusBundle bundle containing a StringArrayList of SKUs with key "ITEM_ID_LIST"
@@ -219,7 +219,7 @@ public interface IInAppBillingService extends android.os.IInterface {
 			 */
 			@Override
 			public android.os.Bundle getSkuDetails(int apiVersion, java.lang.String packageName, java.lang.String type,
-					android.os.Bundle skusBundle) throws android.os.RemoteException {
+												   android.os.Bundle skusBundle) throws android.os.RemoteException {
 				android.os.Parcel _data = android.os.Parcel.obtain();
 				android.os.Parcel _reply = android.os.Parcel.obtain();
 				android.os.Bundle _result;
@@ -247,11 +247,11 @@ public interface IInAppBillingService extends android.os.IInterface {
 				}
 				return _result;
 			}
-			
+
 			/**
 			 * Returns a pending intent to launch the purchase flow for an in-app item by providing a SKU, the type, a
 			 * unique purchase token and an optional developer payload.
-			 * 
+			 *
 			 * @param apiVersion billing API version that the app is using
 			 * @param packageName package name of the calling app
 			 * @param sku the SKU of the in-app item as published in the developer console
@@ -260,7 +260,7 @@ public interface IInAppBillingService extends android.os.IInterface {
 			 * @return Bundle containing the following key-value pairs "RESPONSE_CODE" with int value, RESULT_OK(0) if
 			 *         success, other response codes on failure as listed above. "BUY_INTENT" - PendingIntent to start
 			 *         the purchase flow
-			 * 
+			 *
 			 *         The Pending intent should be launched with startIntentSenderForResult. When purchase flow has
 			 *         completed, the onActivityResult() will give a resultCode of OK or CANCELED. If the purchase is
 			 *         successful, the result data will contain the following key-value pairs "RESPONSE_CODE" with int
@@ -273,7 +273,7 @@ public interface IInAppBillingService extends android.os.IInterface {
 			 */
 			@Override
 			public android.os.Bundle getBuyIntent(int apiVersion, java.lang.String packageName, java.lang.String sku,
-					java.lang.String type, java.lang.String developerPayload) throws android.os.RemoteException {
+												  java.lang.String type, java.lang.String developerPayload) throws android.os.RemoteException {
 				android.os.Parcel _data = android.os.Parcel.obtain();
 				android.os.Parcel _reply = android.os.Parcel.obtain();
 				android.os.Bundle _result;
@@ -297,12 +297,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 				}
 				return _result;
 			}
-			
+
 			/**
 			 * Returns the current SKUs owned by the user of the type and package name specified along with purchase
 			 * information and a signature of the data to be validated. This will return all SKUs that have been
 			 * purchased in V3 and managed items purchased using V1 and V2 that have not been consumed.
-			 * 
+			 *
 			 * @param apiVersion billing API version that the app is using
 			 * @param packageName package name of the calling app
 			 * @param type the type of the in-app items being requested ("inapp" for one-time purchases and "subs" for
@@ -320,7 +320,7 @@ public interface IInAppBillingService extends android.os.IInterface {
 			 */
 			@Override
 			public android.os.Bundle getPurchases(int apiVersion, java.lang.String packageName, java.lang.String type,
-					java.lang.String continuationToken) throws android.os.RemoteException {
+												  java.lang.String continuationToken) throws android.os.RemoteException {
 				android.os.Parcel _data = android.os.Parcel.obtain();
 				android.os.Parcel _reply = android.os.Parcel.obtain();
 				android.os.Bundle _result;
@@ -343,11 +343,11 @@ public interface IInAppBillingService extends android.os.IInterface {
 				}
 				return _result;
 			}
-			
+
 			/**
 			 * Consume the last purchase of the given SKU. This will result in this item being removed from all
 			 * subsequent responses to getPurchases() and allow re-purchase of this item.
-			 * 
+			 *
 			 * @param apiVersion billing API version that the app is using
 			 * @param packageName package name of the calling app
 			 * @param purchaseToken token in the purchase information JSON that identifies the purchase to be consumed
@@ -374,18 +374,18 @@ public interface IInAppBillingService extends android.os.IInterface {
 				return _result;
 			}
 		}
-		
+
 		static final int TRANSACTION_isBillingSupported = (android.os.IBinder.FIRST_CALL_TRANSACTION + 0);
 		static final int TRANSACTION_getSkuDetails = (android.os.IBinder.FIRST_CALL_TRANSACTION + 1);
 		static final int TRANSACTION_getBuyIntent = (android.os.IBinder.FIRST_CALL_TRANSACTION + 2);
 		static final int TRANSACTION_getPurchases = (android.os.IBinder.FIRST_CALL_TRANSACTION + 3);
 		static final int TRANSACTION_consumePurchase = (android.os.IBinder.FIRST_CALL_TRANSACTION + 4);
 	}
-	
+
 	/**
 	 * Checks support for the requested billing API version, package and in-app type. Minimum API version supported by
 	 * this interface is 3.
-	 * 
+	 *
 	 * @param apiVersion the billing version which the app is using
 	 * @param packageName the package name of the calling app
 	 * @param type type of the in-app item being purchased "inapp" for one-time purchases and "subs" for subscription.
@@ -394,12 +394,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 	 */
 	public int isBillingSupported(int apiVersion, java.lang.String packageName, java.lang.String type)
 			throws android.os.RemoteException;
-	
+
 	/**
 	 * Provides details of a list of SKUs Given a list of SKUs of a valid type in the skusBundle, this returns a bundle
 	 * with a list JSON strings containing the productId, price, title and description. This API can be called with a
 	 * maximum of 20 SKUs.
-	 * 
+	 *
 	 * @param apiVersion billing API version that the Third-party is using
 	 * @param packageName the package name of the calling app
 	 * @param type
@@ -411,12 +411,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 	 * @throws android.os.RemoteException
 	 */
 	public android.os.Bundle getSkuDetails(int apiVersion, java.lang.String packageName, java.lang.String type,
-			android.os.Bundle skusBundle) throws android.os.RemoteException;
-	
+										   android.os.Bundle skusBundle) throws android.os.RemoteException;
+
 	/**
 	 * Returns a pending intent to launch the purchase flow for an in-app item by providing a SKU, the type, a unique
 	 * purchase token and an optional developer payload.
-	 * 
+	 *
 	 * @param apiVersion billing API version that the app is using
 	 * @param packageName package name of the calling app
 	 * @param sku the SKU of the in-app item as published in the developer console
@@ -424,7 +424,7 @@ public interface IInAppBillingService extends android.os.IInterface {
 	 * @param developerPayload optional argument to be sent back with the purchase information
 	 * @return Bundle containing the following key-value pairs "RESPONSE_CODE" with int value, RESULT_OK(0) if success,
 	 *         other response codes on failure as listed above. "BUY_INTENT" - PendingIntent to start the purchase flow
-	 * 
+	 *
 	 *         The Pending intent should be launched with startIntentSenderForResult. When purchase flow has completed,
 	 *         the onActivityResult() will give a resultCode of OK or CANCELED. If the purchase is successful, the
 	 *         result data will contain the following key-value pairs "RESPONSE_CODE" with int value, RESULT_OK(0) if
@@ -436,13 +436,13 @@ public interface IInAppBillingService extends android.os.IInterface {
 	 * @throws android.os.RemoteException
 	 */
 	public android.os.Bundle getBuyIntent(int apiVersion, java.lang.String packageName, java.lang.String sku,
-			java.lang.String type, java.lang.String developerPayload) throws android.os.RemoteException;
-	
+										  java.lang.String type, java.lang.String developerPayload) throws android.os.RemoteException;
+
 	/**
 	 * Returns the current SKUs owned by the user of the type and package name specified along with purchase information
 	 * and a signature of the data to be validated. This will return all SKUs that have been purchased in V3 and managed
 	 * items purchased using V1 and V2 that have not been consumed.
-	 * 
+	 *
 	 * @param apiVersion billing API version that the app is using
 	 * @param packageName package name of the calling app
 	 * @param type the type of the in-app items being requested ("inapp" for one-time purchases and "subs" for
@@ -459,12 +459,12 @@ public interface IInAppBillingService extends android.os.IInterface {
 	 * @throws android.os.RemoteException
 	 */
 	public android.os.Bundle getPurchases(int apiVersion, java.lang.String packageName, java.lang.String type,
-			java.lang.String continuationToken) throws android.os.RemoteException;
-	
+										  java.lang.String continuationToken) throws android.os.RemoteException;
+
 	/**
 	 * Consume the last purchase of the given SKU. This will result in this item being removed from all subsequent
 	 * responses to getPurchases() and allow re-purchase of this item.
-	 * 
+	 *
 	 * @param apiVersion billing API version that the app is using
 	 * @param packageName package name of the calling app
 	 * @param purchaseToken token in the purchase information JSON that identifies the purchase to be consumed

--- a/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/Base64.java
+++ b/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/Base64.java
@@ -35,21 +35,21 @@ import com.jdroid.java.exception.UnexpectedException;
 public class Base64 {
 	
 	/** Specify encoding (value is {@code true}). */
-	public final static boolean ENCODE = true;
+	public static final boolean ENCODE = true;
 	
 	/** Specify decoding (value is {@code false}). */
-	public final static boolean DECODE = false;
+	public static final boolean DECODE = false;
 	
 	/** The equals sign (=) as a byte. */
-	private final static byte EQUALS_SIGN = (byte)'=';
+	private static final byte EQUALS_SIGN = (byte)'=';
 	
 	/** The new line character (\n) as a byte. */
-	private final static byte NEW_LINE = (byte)'\n';
+	private static final byte NEW_LINE = (byte)'\n';
 	
 	/**
 	 * The 64 valid Base64 values.
 	 */
-	private final static byte[] ALPHABET = { (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F',
+	private static final byte[] ALPHABET = { (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F',
 			(byte)'G', (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N', (byte)'O',
 			(byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', (byte)'V', (byte)'W', (byte)'X',
 			(byte)'Y', (byte)'Z', (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
@@ -61,7 +61,7 @@ public class Base64 {
 	/**
 	 * The 64 valid web safe Base64 values.
 	 */
-	private final static byte[] WEBSAFE_ALPHABET = { (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F',
+	private static final byte[] WEBSAFE_ALPHABET = { (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F',
 			(byte)'G', (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N', (byte)'O',
 			(byte)'P', (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', (byte)'V', (byte)'W', (byte)'X',
 			(byte)'Y', (byte)'Z', (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f', (byte)'g',
@@ -74,7 +74,7 @@ public class Base64 {
 	 * Translates a Base64 value to either its 6-bit reconstruction value or a negative number indicating some other
 	 * meaning.
 	 **/
-	private final static byte[] DECODABET = { -9, -9, -9, -9, -9, -9, -9, -9, -9, // Decimal 0 - 8
+	private static final byte[] DECODABET = { -9, -9, -9, -9, -9, -9, -9, -9, -9, // Decimal 0 - 8
 			-5, -5, // Whitespace: Tab and Linefeed
 			-9, -9, // Decimal 11 - 12
 			-5, // Whitespace: Carriage Return
@@ -106,9 +106,9 @@ public class Base64 {
 	};
 	
 	// Indicates white space in encoding
-	private final static byte WHITE_SPACE_ENC = -5;
+	private static final byte WHITE_SPACE_ENC = -5;
 	// Indicates equals sign in encoding
-	private final static byte EQUALS_SIGN_ENC = -1;
+	private static final byte EQUALS_SIGN_ENC = -1;
 	
 	/** Defeats instantiation. */
 	private Base64() {

--- a/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/InAppBillingClient.java
+++ b/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/InAppBillingClient.java
@@ -57,7 +57,7 @@ import java.util.Map;
  */
 public class InAppBillingClient {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(InAppBillingClient.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(InAppBillingClient.class);
 	
 	private static final int IN_APP_BILLING_API_VERSION = 3;
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/activity/ActivityHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/activity/ActivityHelper.java
@@ -47,7 +47,7 @@ import java.util.Map;
 
 public class ActivityHelper implements ActivityIf {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(ActivityHelper.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(ActivityHelper.class);
 	
 	private static final int LOCATION_UPDATE_TIMER_CODE = IdGenerator.getIntId();
 	private static final String TITLE_KEY = "title";

--- a/jdroid-android/src/main/java/com/jdroid/android/exception/DefaultExceptionHandler.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/exception/DefaultExceptionHandler.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class DefaultExceptionHandler implements ExceptionHandler {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(DefaultExceptionHandler.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(DefaultExceptionHandler.class);
 	
 	private static final String MAIN_THREAD_NAME = "main";
 

--- a/jdroid-android/src/main/java/com/jdroid/android/fragment/FragmentHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/fragment/FragmentHelper.java
@@ -32,7 +32,7 @@ import java.util.Map;
 
 public class FragmentHelper implements FragmentIf {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(FragmentHelper.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(FragmentHelper.class);
 
 	private Fragment fragment;
 

--- a/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdHelper.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 public class InstanceIdHelper {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(InstanceIdHelper.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(InstanceIdHelper.class);
 
 	private static final String INSTANCE_ID_PREFERENCES = "usageStats";
 

--- a/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdService.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 
 public class InstanceIdService extends InstanceIDListenerService {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(InstanceIdService.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(InstanceIdService.class);
 
 	/**
 	 * Called if InstanceID token is updated. This may occur if the security of

--- a/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationUtils.java
@@ -8,7 +8,7 @@ import com.jdroid.android.utils.ScreenUtils;
 
 public class NotificationUtils {
 	
-	private final static NotificationManager NOTIFICATION_MANAGER = (NotificationManager)AbstractApplication.get().getSystemService(
+	private static final NotificationManager NOTIFICATION_MANAGER = (NotificationManager)AbstractApplication.get().getSystemService(
 		Context.NOTIFICATION_SERVICE);
 	
 	public static void sendNotification(int id, NotificationBuilder notificationBuilder) {

--- a/jdroid-android/src/main/java/com/jdroid/android/permission/PermissionHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/permission/PermissionHelper.java
@@ -410,7 +410,7 @@ public class PermissionHelper {
 	}
 
 
-	protected static abstract class PermissionDelegate {
+	protected abstract static class PermissionDelegate {
 
 		public abstract FragmentActivity getActivity();
 

--- a/jdroid-android/src/main/java/com/jdroid/android/recycler/RecyclerViewType.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/recycler/RecyclerViewType.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 
 public abstract class RecyclerViewType<ITEM, VIEWHOLDER extends RecyclerView.ViewHolder> implements View.OnClickListener {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(RecyclerViewType.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(RecyclerViewType.class);
 
 	public View inflateView(LayoutInflater inflater, ViewGroup parent) {
 		View view = inflater.inflate(getLayoutResourceId(), parent, false);

--- a/jdroid-android/src/main/java/com/jdroid/android/search/SingleLineSuggestionsProvider.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/search/SingleLineSuggestionsProvider.java
@@ -17,8 +17,8 @@ import com.jdroid.android.utils.AppUtils;
 @SuppressLint("Registered")
 public class SingleLineSuggestionsProvider extends SearchRecentSuggestionsProvider {
 	
-	public final static String AUTHORITY = AppUtils.getApplicationId() + ".SingleLineSuggestionsProvider";
-	public final static int MODE = DATABASE_MODE_QUERIES;
+	public static final String AUTHORITY = AppUtils.getApplicationId() + ".SingleLineSuggestionsProvider";
+	public static final int MODE = DATABASE_MODE_QUERIES;
 	
 	public SingleLineSuggestionsProvider() {
 		setupSuggestions(AUTHORITY, MODE);

--- a/jdroid-android/src/main/java/com/jdroid/android/search/TwoLinesSuggestionsProvider.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/search/TwoLinesSuggestionsProvider.java
@@ -17,8 +17,8 @@ import com.jdroid.android.utils.AppUtils;
 @SuppressLint("Registered")
 public class TwoLinesSuggestionsProvider extends SearchRecentSuggestionsProvider {
 	
-	public final static String AUTHORITY = AppUtils.getApplicationId() + ".TwoLinesSuggestionsProvider";
-	public final static int MODE = DATABASE_MODE_QUERIES | DATABASE_MODE_2LINES;
+	public static final String AUTHORITY = AppUtils.getApplicationId() + ".TwoLinesSuggestionsProvider";
+	public static final int MODE = DATABASE_MODE_QUERIES | DATABASE_MODE_2LINES;
 	
 	public TwoLinesSuggestionsProvider() {
 		setupSuggestions(AUTHORITY, MODE);

--- a/jdroid-android/src/main/java/com/jdroid/android/service/AbstractGcmTaskService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/service/AbstractGcmTaskService.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 
 public abstract class AbstractGcmTaskService extends GcmTaskService {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(GcmTaskService.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(GcmTaskService.class);
 
 	@Override
 	public void onInitializeTasks() {

--- a/jdroid-android/src/main/java/com/jdroid/android/service/CommandGcmTaskService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/service/CommandGcmTaskService.java
@@ -7,7 +7,7 @@ import com.jdroid.java.utils.ReflectionUtils;
 
 public class CommandGcmTaskService extends AbstractGcmTaskService {
 
-	public final static String COMMAND_EXTRA = "command";
+	public static final String COMMAND_EXTRA = "command";
 
 	@Override
 	public void onInitializeTasks() {

--- a/jdroid-android/src/main/java/com/jdroid/android/service/CommandWorkerService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/service/CommandWorkerService.java
@@ -11,9 +11,9 @@ import org.slf4j.Logger;
 
 public class CommandWorkerService extends WorkerService {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(CommandWorkerService.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(CommandWorkerService.class);
 
-	public final static String COMMAND_EXTRA = "command";
+	public static final String COMMAND_EXTRA = "command";
 
 	@Override
 	protected String getTrackingLabel(Intent intent) {

--- a/jdroid-android/src/main/java/com/jdroid/android/service/ServiceCommand.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/service/ServiceCommand.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
 
 public abstract class ServiceCommand implements Serializable {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(ServiceCommand.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(ServiceCommand.class);
 
 	public void start() {
 		start(null);

--- a/jdroid-android/src/main/java/com/jdroid/android/service/WorkerService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/service/WorkerService.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 
 public abstract class WorkerService extends IntentService {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(WorkerService.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(WorkerService.class);
 
 	private static String TAG = WorkerService.class.getSimpleName();
 

--- a/jdroid-android/src/main/java/com/jdroid/android/sqlite/SQLiteHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/sqlite/SQLiteHelper.java
@@ -17,8 +17,8 @@ import java.util.Set;
 
 public class SQLiteHelper extends SQLiteOpenHelper {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(SQLiteHelper.class);
-	private final static String DB_NAME = "application.db";
+	private static final Logger LOGGER = LoggerUtils.getLogger(SQLiteHelper.class);
+	private static final String DB_NAME = "application.db";
 	
 	private Set<String> createSQLs = Sets.newHashSet();
 	private List<SQLiteUpgradeStep> upgradeSteps = Lists.newArrayList();

--- a/jdroid-android/src/main/java/com/jdroid/android/usecase/AbstractUseCase.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/usecase/AbstractUseCase.java
@@ -17,7 +17,7 @@ public abstract class AbstractUseCase implements Runnable, Serializable {
 	
 	private static final long serialVersionUID = 3732327346852606739L;
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(AbstractUseCase.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(AbstractUseCase.class);
 	
 	public enum UseCaseStatus {
 		NOT_INVOKED,

--- a/jdroid-android/src/main/java/com/jdroid/android/usecase/PaginatedUseCase.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/usecase/PaginatedUseCase.java
@@ -22,7 +22,7 @@ public abstract class PaginatedUseCase<T> extends AbstractUseCase {
 		SORTING;
 	}
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(PaginatedUseCase.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(PaginatedUseCase.class);
 	
 	private PaginatedUseCaseMode paginatedUseCaseMode = PaginatedUseCaseMode.INITIAL_LOAD;
 	private int page = 1;

--- a/jdroid-android/src/main/java/com/jdroid/android/usecase/service/UseCaseService.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/usecase/service/UseCaseService.java
@@ -12,8 +12,8 @@ import com.jdroid.java.concurrent.ExecutorUtils;
 @SuppressLint("Registered")
 public class UseCaseService extends WorkerService {
 	
-	private final static String USE_CASE = "useCase";
-	private final static String NOTIFICATION_TO_CANCEL_ID = "notificationToCancelId";
+	private static final String USE_CASE = "useCase";
+	private static final String NOTIFICATION_TO_CANCEL_ID = "notificationToCancelId";
 	
 	@Override
 	protected void doExecute(Intent intent) {

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/AlarmUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/AlarmUtils.java
@@ -10,7 +10,7 @@ import com.jdroid.java.utils.LoggerUtils;
 
 public class AlarmUtils {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(AlarmUtils.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(AlarmUtils.class);
 	
 	public static void scheduleRtcWakeUpAlarm(long triggerAtTime, PendingIntent operation) {
 		getAlarmManager().set(AlarmManager.RTC_WAKEUP, triggerAtTime, operation);

--- a/jdroid-java/src/main/java/com/jdroid/java/http/AbstractHttpResponseValidator.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/http/AbstractHttpResponseValidator.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 
 public abstract class AbstractHttpResponseValidator extends BasicHttpResponseValidator {
 
-	private final static Logger LOGGER = LoggerUtils.getLogger(AbstractHttpResponseValidator.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(AbstractHttpResponseValidator.class);
 
 	private static final String STATUS_CODE_HEADER = "status-code";
 	private static final String SUCCESSFUL_STATUS_CODE = "200";

--- a/jdroid-java/src/main/java/com/jdroid/java/http/HttpResponseWrapper.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/http/HttpResponseWrapper.java
@@ -8,7 +8,7 @@ import java.io.InputStream;
 
 public abstract class HttpResponseWrapper {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(HttpResponseWrapper.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(HttpResponseWrapper.class);
 	
 	public abstract int getStatusCode();
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/http/mock/JsonMockHttpService.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/http/mock/JsonMockHttpService.java
@@ -2,8 +2,8 @@ package com.jdroid.java.http.mock;
 
 public abstract class JsonMockHttpService extends AbstractMockHttpService {
 	
-	private final static String MOCKS_BASE_PATH = "mocks/json/";
-	private final static String MOCKS_EXTENSION = ".json";
+	private static final String MOCKS_BASE_PATH = "mocks/json/";
+	private static final String MOCKS_EXTENSION = ".json";
 	
 	public JsonMockHttpService(Object... urlSegments) {
 		super(urlSegments);

--- a/jdroid-java/src/main/java/com/jdroid/java/http/mock/XmlMockHttpService.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/http/mock/XmlMockHttpService.java
@@ -2,8 +2,8 @@ package com.jdroid.java.http.mock;
 
 public abstract class XmlMockHttpService extends AbstractMockHttpService {
 	
-	private final static String MOCKS_BASE_PATH = "mocks/xml/";
-	private final static String MOCKS_EXTENSION = ".xml";
+	private static final String MOCKS_BASE_PATH = "mocks/xml/";
+	private static final String MOCKS_EXTENSION = ".xml";
 	
 	public XmlMockHttpService(Object... urlSegments) {
 		super(urlSegments);

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/EncodingUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/EncodingUtils.java
@@ -9,7 +9,7 @@ public class EncodingUtils {
 	public static final String UTF8 = "UTF-8";
 	private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 	/** Index of a component which was not found. */
-	private final static int NOT_FOUND = -1;
+	private static final int NOT_FOUND = -1;
 	
 	/**
 	 * Encodes characters in the given string as '%'-escaped octets using the UTF-8 scheme. Leaves letters ("A-Z",

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/StringUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/StringUtils.java
@@ -16,20 +16,20 @@ import java.util.regex.Pattern;
  */
 public abstract class StringUtils {
 	
-	public final static String EMPTY = "";
-	public final static String ELLIPSIS = "...";
-	public final static String COMMA = ",";
-	public final static String SPACE = " ";
-	public final static String DASH = "-";
-	public final static String SLASH = "/";
-	public final static String DOT = ".";
-	public final static String NEW_LINE = "\n";
-	public final static String UNDERSCORE = "_";
-	public final static String BANG = "!";
-	public final static String PIPE = "|";
+	public static final String EMPTY = "";
+	public static final String ELLIPSIS = "...";
+	public static final String COMMA = ",";
+	public static final String SPACE = " ";
+	public static final String DASH = "-";
+	public static final String SLASH = "/";
+	public static final String DOT = ".";
+	public static final String NEW_LINE = "\n";
+	public static final String UNDERSCORE = "_";
+	public static final String BANG = "!";
+	public static final String PIPE = "|";
 	
-	private final static String PLACEHOLDER_PATTERN = "\\$\\{(.*?)\\}";
-	private final static String ALPHANUMERIC_PATTERN = "([^\\w\\s])*";
+	private static final String PLACEHOLDER_PATTERN = "\\$\\{(.*?)\\}";
+	private static final String ALPHANUMERIC_PATTERN = "([^\\w\\s])*";
 	
 	public static String getNotEmptyString(String text) {
 		return StringUtils.isEmpty(text) ? null : text;

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/exception/DefaultExceptionHandler.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/exception/DefaultExceptionHandler.java
@@ -8,7 +8,7 @@ import java.lang.Thread.UncaughtExceptionHandler;
 
 public class DefaultExceptionHandler implements UncaughtExceptionHandler {
 	
-	private final static Logger LOGGER = LoggerUtils.getLogger(DefaultExceptionHandler.class);
+	private static final Logger LOGGER = LoggerUtils.getLogger(DefaultExceptionHandler.class);
 	
 	private UncaughtExceptionHandler wrappedExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
 

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/google/gcm/GcmSender.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/google/gcm/GcmSender.java
@@ -25,7 +25,7 @@ public class GcmSender implements PushMessageSender {
 	// Maximum delay before a retry.
 	protected static final int MAX_BACKOFF_DELAY = 1024000;
 	
-	private final static PushMessageSender INSTANCE = new GcmSender();
+	private static final PushMessageSender INSTANCE = new GcmSender();
 
 	private GcmApiService gcmApiService = new GcmApiService();
 	

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/search/Pager.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/search/Pager.java
@@ -4,8 +4,8 @@ import com.jdroid.java.exception.UnexpectedException;
 
 public class Pager {
 	
-	private final static Integer DEFAULT_PAGE = 1;
-	private final static Integer DEFAULT_PAGE_SIZE = 25;
+	private static final Integer DEFAULT_PAGE = 1;
+	private static final Integer DEFAULT_PAGE_SIZE = 25;
 	
 	private Integer size;
 	private Integer page;

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/utils/CSVUtils.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/utils/CSVUtils.java
@@ -38,7 +38,7 @@ public class CSVUtils {
 	
 	public static class StringConverter implements ValueConverter<String> {
 		
-		private final static StringConverter INSTANCE = new StringConverter();
+		private static final StringConverter INSTANCE = new StringConverter();
 		
 		public static StringConverter get() {
 			return INSTANCE;
@@ -63,7 +63,7 @@ public class CSVUtils {
 	
 	public static class LongConverter implements ValueConverter<Long> {
 		
-		private final static LongConverter INSTANCE = new LongConverter();
+		private static final LongConverter INSTANCE = new LongConverter();
 		
 		public static LongConverter get() {
 			return INSTANCE;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”.

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Soso Tughushi.
