### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/jdroid-android-about/src/main/java/com/jdroid/android/about/appinvite/AppInviteHelper.java
+++ b/jdroid-android-about/src/main/java/com/jdroid/android/about/appinvite/AppInviteHelper.java
@@ -10,6 +10,8 @@ import com.jdroid.java.collections.Lists;
 
 public class AppInviteHelper {
 
+	private AppInviteHelper(){}
+
 	public static void onActivityResult(int appInviteRequestCode, int requestCode, int resultCode, Intent data) {
 
 		if (requestCode == appInviteRequestCode) {

--- a/jdroid-android-about/src/main/java/com/jdroid/android/about/appinvite/AppInviteStats.java
+++ b/jdroid-android-about/src/main/java/com/jdroid/android/about/appinvite/AppInviteStats.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public class AppInviteStats {
 
+	private AppInviteStats(){}
+
 	private static final String APP_INVITE_STATS = "appInviteStats";
 
 	private static final String LAST_INVITE_SENT_TIMESTAMP = "lastInviteSentTimestamp";

--- a/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/InAppBillingHelper.java
+++ b/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/InAppBillingHelper.java
@@ -7,6 +7,8 @@ import com.jdroid.android.application.AbstractApplication;
 
 public class InAppBillingHelper {
 
+	private InAppBillingHelper(){}
+
 	private static Boolean inAppBillingLoaded = false;
 
 	public static void onCreate(FragmentActivity activity, Bundle savedInstanceState) {

--- a/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/Security.java
+++ b/jdroid-android-google-inappbilling/src/main/java/com/jdroid/android/google/inappbilling/Security.java
@@ -27,6 +27,8 @@ import android.util.Log;
  * code to make it harder for an attacker to replace the code with stubs that treat all purchases as verified.
  */
 public class Security {
+
+	private Security(){}
 	
 	private static final String TAG = "IABUtil/Security";
 	

--- a/jdroid-android/src/debug/java/com/jdroid/android/debug/CrashGenerator.java
+++ b/jdroid-android/src/debug/java/com/jdroid/android/debug/CrashGenerator.java
@@ -5,6 +5,8 @@ import com.jdroid.java.concurrent.ExecutorUtils;
 import com.jdroid.java.exception.AbstractException;
 
 public class CrashGenerator {
+
+	private CrashGenerator(){}
 	
 	public static void crash(final ExceptionType exceptionType, Boolean executeOnNewThread) {
 		Runnable runnable = new Runnable() {

--- a/jdroid-android/src/main/java/com/jdroid/android/activity/ActivityLauncher.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/activity/ActivityLauncher.java
@@ -14,6 +14,8 @@ import com.jdroid.android.application.AbstractApplication;
  * Launcher for all the activities of the application
  */
 public class ActivityLauncher {
+
+	private ActivityLauncher(){}
 	
 	/**
 	 * Launches the {@link AbstractApplication#getHomeActivityClass()}

--- a/jdroid-android/src/main/java/com/jdroid/android/barcode/BarcodeUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/barcode/BarcodeUtils.java
@@ -22,6 +22,8 @@ import com.jdroid.java.utils.RandomUtils;
  * 
  */
 public final class BarcodeUtils {
+
+	private BarcodeUtils(){}
 	
 	private static final int REQUEST_CODE = RandomUtils.get16BitsInt();
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/context/UsageStats.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/context/UsageStats.java
@@ -5,6 +5,8 @@ import com.jdroid.java.date.DateUtils;
 
 public class UsageStats {
 
+	private UsageStats(){}
+
 	private static final String USAGE_STATS = "usageStats";
 	private static final String APP_LOADS = "appLoads";
 	private static final String FIRST_APP_LOAD_TIMESTAMP = "firstAppLoadTimestamp";

--- a/jdroid-android/src/main/java/com/jdroid/android/date/AndroidDateUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/date/AndroidDateUtils.java
@@ -9,6 +9,8 @@ import com.jdroid.java.date.DateUtils;
  * Date Utils that returns formatted times & dates according to the current locale and user preferences
  */
 public class AndroidDateUtils {
+
+	private AndroidDateUtils(){}
 	
 	/**
 	 * @return The formatted time

--- a/jdroid-android/src/main/java/com/jdroid/android/facebook/FacebookHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/facebook/FacebookHelper.java
@@ -10,6 +10,8 @@ import com.jdroid.android.social.SocialAction;
 
 public class FacebookHelper {
 
+	private FacebookHelper(){}
+
 	public static void openPage(String pageId) {
 		try {
 			Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("fb://page/" + pageId));

--- a/jdroid-android/src/main/java/com/jdroid/android/feedback/RateAppStats.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/feedback/RateAppStats.java
@@ -6,6 +6,8 @@ import com.jdroid.java.date.DateUtils;
 
 public class RateAppStats {
 
+	private RateAppStats(){}
+
 	private static final String RATE_APP_STATS = "rateAppStats";
 	private static final String LAST_RESPONSE_TIMESTAMP = "lastResponseTimestamp";
 	private static final String ENJOYING = "enjoying";

--- a/jdroid-android/src/main/java/com/jdroid/android/google/GooglePlayServicesUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/google/GooglePlayServicesUtils.java
@@ -14,6 +14,8 @@ import org.slf4j.Logger;
 
 public class GooglePlayServicesUtils {
 
+	private GooglePlayServicesUtils(){}
+
 	private static final Logger LOGGER = LoggerUtils.getLogger(GooglePlayServicesUtils.class);
 
 	private static final String GOOGLE_PLAY_SERVICES = "com.google.android.gms";

--- a/jdroid-android/src/main/java/com/jdroid/android/google/GooglePlayUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/google/GooglePlayUtils.java
@@ -12,6 +12,8 @@ import com.jdroid.android.intent.IntentUtils;
 import com.jdroid.android.utils.AppUtils;
 
 public class GooglePlayUtils {
+
+	private GooglePlayUtils(){}
 	
 	private static final String GOOGLE_PLAY_DETAILS_LINK = "http://play.google.com/store/apps/details?id=";
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/google/instanceid/InstanceIdHelper.java
@@ -13,6 +13,8 @@ import java.util.UUID;
 
 public class InstanceIdHelper {
 
+	private InstanceIdHelper(){}
+
 	private final static Logger LOGGER = LoggerUtils.getLogger(InstanceIdHelper.class);
 
 	private static final String INSTANCE_ID_PREFERENCES = "usageStats";

--- a/jdroid-android/src/main/java/com/jdroid/android/images/BitmapUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/images/BitmapUtils.java
@@ -12,6 +12,8 @@ import android.util.Log;
 import com.jdroid.android.application.AbstractApplication;
 
 public class BitmapUtils {
+
+	private BitmapUtils(){}
 	
 	public static Bitmap toBitmap(int resId, Integer maxWidth, Integer maxHeight) {
 		Bitmap bitmap = BitmapFactory.decodeResource(AbstractApplication.get().getResources(), resId);

--- a/jdroid-android/src/main/java/com/jdroid/android/intent/IntentUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/intent/IntentUtils.java
@@ -9,6 +9,8 @@ import android.net.Uri;
 import com.jdroid.android.application.AbstractApplication;
 
 public class IntentUtils {
+
+	private IntentUtils(){}
 	
 	/**
 	 * Indicates whether the specified action can be used as an intent. This method queries the package manager for

--- a/jdroid-android/src/main/java/com/jdroid/android/log/AndroidLoggerUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/log/AndroidLoggerUtils.java
@@ -6,6 +6,8 @@ import org.slf4j.Logger;
 
 public class AndroidLoggerUtils {
 
+	private AndroidLoggerUtils(){}
+
 	public static Logger getDatabaseLogger(Class<?> clazz) {
 		if (LoggerUtils.isEnabled()) {
 			return new DatabaseLogger(LoggerUtils.getLogger(clazz));

--- a/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/notification/NotificationUtils.java
@@ -7,6 +7,8 @@ import com.jdroid.android.application.AbstractApplication;
 import com.jdroid.android.utils.ScreenUtils;
 
 public class NotificationUtils {
+
+	private NotificationUtils(){}
 	
 	private final static NotificationManager NOTIFICATION_MANAGER = (NotificationManager)AbstractApplication.get().getSystemService(
 		Context.NOTIFICATION_SERVICE);

--- a/jdroid-android/src/main/java/com/jdroid/android/share/ShareUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/share/ShareUtils.java
@@ -13,6 +13,8 @@ import com.jdroid.java.http.MimeType;
 import com.jdroid.java.utils.EncodingUtils;
 
 public class ShareUtils {
+
+	public ShareUtils(){}
 	
 	public static void shareTextContent(String shareKey, int shareTitle, int shareSubject, int shareText) {
 		Activity activity = AbstractApplication.get().getCurrentActivity();

--- a/jdroid-android/src/main/java/com/jdroid/android/social/twitter/TwitterConnector.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/social/twitter/TwitterConnector.java
@@ -8,6 +8,8 @@ import com.jdroid.android.social.AccountType;
 import com.jdroid.android.social.SocialAction;
 
 public class TwitterConnector {
+
+	private TwitterConnector(){}
 	
 	public static Integer CHARACTERS_LIMIT = 140;
 	public static Integer URL_CHARACTERS_COUNT = 22;

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/AlarmUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/AlarmUtils.java
@@ -9,6 +9,8 @@ import com.jdroid.java.date.DateUtils;
 import com.jdroid.java.utils.LoggerUtils;
 
 public class AlarmUtils {
+
+	private AlarmUtils(){}
 	
 	private final static Logger LOGGER = LoggerUtils.getLogger(AlarmUtils.class);
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/AndroidEncryptionUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/AndroidEncryptionUtils.java
@@ -19,6 +19,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 public class AndroidEncryptionUtils {
+
+	private AndroidEncryptionUtils(){}
 	
 	private static final String BASE64_KEY = "base64Key";
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/AndroidUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/AndroidUtils.java
@@ -13,6 +13,8 @@ import com.jdroid.java.utils.ValidationUtils;
 import java.util.List;
 
 public class AndroidUtils {
+
+	private AndroidUtils(){}
 	
 	public static Integer getApiLevel() {
 		return android.os.Build.VERSION.SDK_INT;

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/AppUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/AppUtils.java
@@ -14,6 +14,8 @@ import com.jdroid.android.application.AbstractApplication;
 
 public class AppUtils {
 
+	private AppUtils(){}
+
 	/**
 	 * @return The version name of the application
 	 */

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/DeviceUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/DeviceUtils.java
@@ -20,6 +20,8 @@ import com.jdroid.java.utils.StringUtils;
 
 public class DeviceUtils {
 
+	private DeviceUtils(){}
+
 	private static final String DEVICE_YEAR_CLASS = "DeviceYearClass";
 
 	private static Integer deviceYearClass = YearClass.CLASS_UNKNOWN;

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/ExternalAppsUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/ExternalAppsUtils.java
@@ -16,6 +16,8 @@ import com.jdroid.android.google.GooglePlayUtils;
 import com.jdroid.android.intent.IntentUtils;
 
 public class ExternalAppsUtils {
+
+	private ExternalAppsUtils(){}
 	
 	public static final String TWITTER_PACKAGE_NAME = "com.twitter.android";
 	public static final String FACEBOOK_PACKAGE_NAME = "com.facebook.katana";

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/LocalizationUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/LocalizationUtils.java
@@ -4,6 +4,8 @@ import com.jdroid.android.application.AbstractApplication;
 import com.jdroid.java.exception.ErrorCode;
 
 public final class LocalizationUtils {
+
+	private LocalizationUtils(){}
 	
 	/**
 	 * Returns a formatted string, using the localized resource as format and the supplied arguments

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/ScreenUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/ScreenUtils.java
@@ -14,6 +14,8 @@ import com.jdroid.android.R;
 import com.jdroid.java.utils.StringUtils;
 
 public class ScreenUtils {
+
+	private ScreenUtils(){}
 	
 	public static final String LDPI_DENSITY_NAME = "ldpi";
 	public static final String MDPI_DENSITY_NAME = "mdpi";

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/ToastUtils.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/ToastUtils.java
@@ -8,6 +8,8 @@ import com.jdroid.android.application.AbstractApplication;
 import java.lang.ref.WeakReference;
 
 public final class ToastUtils {
+
+	private ToastUtils(){}
 	
 	private static final int DEFAULT_DURATION = Toast.LENGTH_LONG;
 	

--- a/jdroid-android/src/main/java/com/jdroid/android/utils/TooltipHelper.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/utils/TooltipHelper.java
@@ -18,6 +18,8 @@ import android.widget.Toast;
  * > ActionMenuItemView.java</a>.
  */
 public class TooltipHelper {
+
+	private TooltipHelper(){}
 	
 	/**
 	 * The estimated height of a toast, in dps (density-independent pixels). This is used to determine whether or not

--- a/jdroid-android/src/main/java/com/jdroid/android/voice/VoiceRecognizerIntent.java
+++ b/jdroid-android/src/main/java/com/jdroid/android/voice/VoiceRecognizerIntent.java
@@ -24,6 +24,8 @@ import java.util.List;
  * </p>
  */
 public class VoiceRecognizerIntent {
+
+	private VoiceRecognizerIntent(){}
 	
 	private static final int REQUEST_CODE = RandomUtils.get16BitsInt();
 	private static final String PACKAGE = "com.google.android.voicesearch";

--- a/jdroid-gradle-plugin/src/main/java/com/jdroid/android/dex/Output.java
+++ b/jdroid-gradle-plugin/src/main/java/com/jdroid/android/dex/Output.java
@@ -22,6 +22,9 @@ import java.io.PrintStream;
  * Generate fancy output.
  */
 public class Output {
+
+    private Output(){}
+
     private static final String IN0 = "";
     private static final String IN1 = "  ";
     private static final String IN2 = "    ";

--- a/jdroid-gradle-plugin/src/main/java/com/jdroid/android/publisher/GooglePlayPublisher.java
+++ b/jdroid-gradle-plugin/src/main/java/com/jdroid/android/publisher/GooglePlayPublisher.java
@@ -48,6 +48,8 @@ import java.util.List;
  */
 public class GooglePlayPublisher {
 
+	private GooglePlayPublisher(){}
+
 	private static final Logger LOGGER = LoggerUtils.getLogger(GooglePlayPublisher.class);
 
 	public static final String MIME_TYPE_APK = "application/vnd.android.package-archive";

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/Iterables.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/Iterables.java
@@ -3,6 +3,8 @@ package com.jdroid.java.collections;
 import java.util.Collection;
 
 public class Iterables {
+
+	private Iterables(){}
 	
 	/**
 	 * Returns the number of elements in {@code iterable}.

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/Iterators.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/Iterators.java
@@ -3,6 +3,8 @@ package com.jdroid.java.collections;
 import java.util.Iterator;
 
 public class Iterators {
+
+	private Iterators(){}
 	
 	/**
 	 * Returns the number of elements remaining in {@code iterator}. The iterator will be left exhausted: its

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/Lists.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/Lists.java
@@ -8,6 +8,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class Lists {
+
+	private Lists(){}
 	
 	// ArrayList
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/Maps.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/Maps.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Maps {
+
+	private Maps(){}
 	
 	/**
 	 * Creates a <i>mutable</i>, empty {@code HashMap} instance.

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/ObjectArrays.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/ObjectArrays.java
@@ -3,6 +3,8 @@ package com.jdroid.java.collections;
 import java.lang.reflect.Array;
 
 public class ObjectArrays {
+
+	private ObjectArrays(){}
 	
 	/**
 	 * Returns a new array of the given length with the specified component type.

--- a/jdroid-java/src/main/java/com/jdroid/java/collections/Sets.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/collections/Sets.java
@@ -8,6 +8,8 @@ import java.util.LinkedHashSet;
 import java.util.TreeSet;
 
 public class Sets {
+
+	private Sets(){}
 	
 	// HashSet
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/concurrent/ExecutorUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/concurrent/ExecutorUtils.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import com.jdroid.java.utils.LoggerUtils;
 
 public final class ExecutorUtils {
+
+	private ExecutorUtils(){}
 	
 	private static final Logger LOGGER = LoggerUtils.getLogger(ExecutorUtils.class);
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/date/DateTimeFormat.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/date/DateTimeFormat.java
@@ -2,6 +2,8 @@ package com.jdroid.java.date;
 
 public class DateTimeFormat {
 
+	private DateTimeFormat(){}
+
 	/** Date format like 2013-01-11T20:30:00.000 */
 	public static final String YYYYMMDDTHHMMSSSSS = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 

--- a/jdroid-java/src/main/java/com/jdroid/java/date/DateUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/date/DateUtils.java
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
  * Utilities for Dates and Calendars
  */
 public abstract class DateUtils {
+
+	private DateUtils(){}
 	
 	/** Seconds in a minute */
 	public static final int SECONDS_PER_MINUTE = 60;

--- a/jdroid-java/src/main/java/com/jdroid/java/http/MimeType.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/http/MimeType.java
@@ -1,6 +1,8 @@
 package com.jdroid.java.http;
 
 public class MimeType {
+
+	private MimeType(){}
 	
 	public static final String TEXT = "text/plain";
 	public static final String HTML = "text/html";

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/CopyUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/CopyUtils.java
@@ -11,6 +11,8 @@ import java.io.Serializable;
 
 public class CopyUtils {
 
+	private CopyUtils(){}
+
 	@SuppressWarnings("unchecked")
 	public static <T extends Serializable> T cloneSerializable(T object) {
 		T cloneObject;

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/EncodingUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/EncodingUtils.java
@@ -5,6 +5,8 @@ import com.jdroid.java.exception.UnexpectedException;
 import java.io.UnsupportedEncodingException;
 
 public class EncodingUtils {
+
+	private EncodingUtils(){}
 	
 	public static final String UTF8 = "UTF-8";
 	private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/EncryptionUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/EncryptionUtils.java
@@ -15,6 +15,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 public class EncryptionUtils {
+
+	private EncryptionUtils(){}
 	
 	private static final String AES = "AES";
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/IdGenerator.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/IdGenerator.java
@@ -1,6 +1,8 @@
 package com.jdroid.java.utils;
 
 public class IdGenerator {
+
+	private IdGenerator(){}
 	
 	private static Integer ID = 10000;
 	

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/LocaleUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/LocaleUtils.java
@@ -4,6 +4,8 @@ import java.util.Locale;
 
 public class LocaleUtils {
 
+	private LocaleUtils(){}
+
 	public static String getAcceptLanguage() {
 		String language = Locale.getDefault().getLanguage();
 		String country = Locale.getDefault().getCountry();

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/LoggerUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/LoggerUtils.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 public class LoggerUtils {
+
+	private LoggerUtils(){}
 	
 	private static boolean enabled = false;
 	private static ExceptionLogger exceptionLogger;

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/NumberUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/NumberUtils.java
@@ -3,6 +3,8 @@ package com.jdroid.java.utils;
 import java.text.DecimalFormat;
 
 public class NumberUtils {
+
+	private NumberUtils(){}
 	
 	public static Float getFloat(String value) {
 		return getFloat(value, null);

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/ObjectUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/ObjectUtils.java
@@ -6,6 +6,8 @@ package com.jdroid.java.utils;
  * </p>
  */
 public class ObjectUtils {
+
+	private ObjectUtils(){}
 	
 	/**
 	 * <p>

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/RandomUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/RandomUtils.java
@@ -4,6 +4,8 @@ import java.util.Random;
 
 public class RandomUtils {
 
+	private RandomUtils(){}
+
 	private static final Random RANDOM = new Random();
 
 	public static Long getLong() {

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/Sanitizer.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/Sanitizer.java
@@ -3,6 +3,8 @@ package com.jdroid.java.utils;
 import java.text.Normalizer;
 
 public class Sanitizer {
+
+	private Sanitizer(){}
 	
 	public static String plainString(String text) {
 		String plain = null;

--- a/jdroid-java/src/main/java/com/jdroid/java/utils/ValidationUtils.java
+++ b/jdroid-java/src/main/java/com/jdroid/java/utils/ValidationUtils.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
  * Validation Utils
  */
 public class ValidationUtils {
+
+	private ValidationUtils(){}
 	
 	public static final Pattern EMAIL_PATTERN = Pattern.compile("^[_A-Za-z0-9\\+-]+(\\.[_A-Za-z0-9\\+-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*((\\.[A-Za-z]{2,}){1}$)");
 	

--- a/jdroid-javaweb/src/main/java/com/jdroid/javaweb/utils/CSVUtils.java
+++ b/jdroid-javaweb/src/main/java/com/jdroid/javaweb/utils/CSVUtils.java
@@ -28,6 +28,8 @@ import au.com.bytecode.opencsv.CSVWriter;
  * Utilities for CSV
  */
 public class CSVUtils {
+
+	private CSVUtils(){}
 	
 	public static interface ValueConverter<T> {
 		


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi
